### PR TITLE
make riot global var available to api.js for testing

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 require("../bower_components/riotjs/bdd.js");
 
 // jQuery object with Riot functions
-global.$ = require("../bower_components/riotjs/riot.js");
+global.$ = global.riot = require("../bower_components/riotjs/riot.js");
 
 // $ utility functions used by the API (from lodash)
 var _ = require("lodash");


### PR DESCRIPTION
Maybe there's a better way? 

Fix for:

$ ./make.js test

riotjs-admin/dist/api.js:124
top.admin = riot.observable(function(arg) {
                    ^
ReferenceError: riot is not defined
